### PR TITLE
Add Node/Express chat web app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+chat_app_js/node_modules/
+__pycache__/
+*.pyc

--- a/chat_app_js/README.md
+++ b/chat_app_js/README.md
@@ -1,0 +1,19 @@
+# Chat Application with ZeroGPT
+
+This directory contains a simple Node.js/Express.js web chat that uses the Python `zerogpt` library to generate responses.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Run the server:
+   ```bash
+   node index.js
+   ```
+3. Open `http://localhost:3000` in your browser.
+
+## Save feature
+
+Each message from the bot includes a **Sauvegarder** button. Clicking it stores the text in `saved_messages.json` on the server.

--- a/chat_app_js/index.js
+++ b/chat_app_js/index.js
@@ -1,0 +1,41 @@
+const express = require('express');
+const { execFile } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.use(express.json());
+app.use(express.static(path.join(__dirname, 'public')));
+
+app.post('/api/send', (req, res) => {
+  const message = req.body.message || '';
+  const python = execFile('python3', [path.join(__dirname, 'zerogpt_bridge.py'), message], { encoding: 'utf8' }, (err, stdout, stderr) => {
+    if (err) {
+      console.error(stderr);
+      return res.status(500).json({ error: 'python error' });
+    }
+    try {
+      const data = JSON.parse(stdout.trim());
+      res.json(data);
+    } catch (e) {
+      console.error('Parse error:', stdout);
+      res.status(500).json({ error: 'invalid response' });
+    }
+  });
+});
+
+app.post('/api/save', (req, res) => {
+  const text = req.body.text || '';
+  const file = path.join(__dirname, 'saved_messages.json');
+  let arr = [];
+  if (fs.existsSync(file)) {
+    arr = JSON.parse(fs.readFileSync(file));
+  }
+  arr.push({ text, date: new Date().toISOString() });
+  fs.writeFileSync(file, JSON.stringify(arr, null, 2));
+  res.json({ status: 'ok' });
+});
+
+app.listen(PORT, () => console.log(`Server running on port ${PORT}`));

--- a/chat_app_js/package.json
+++ b/chat_app_js/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "chat_app_js",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^5.1.0"
+  }
+}

--- a/chat_app_js/public/index.html
+++ b/chat_app_js/public/index.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ZeroGPT Chat</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        #messages { border: 1px solid #ccc; padding: 10px; height: 300px; overflow-y: scroll; }
+        .message { margin-bottom: 10px; }
+        button.save-btn { margin-left: 10px; }
+    </style>
+</head>
+<body>
+    <h1>ZeroGPT Chat</h1>
+    <div id="messages"></div>
+    <input type="text" id="input" placeholder="Votre message" style="width:80%">
+    <button id="send">Envoyer</button>
+
+<script>
+async function sendMessage() {
+    const text = document.getElementById('input').value;
+    const res = await fetch('/api/send', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: text })
+    });
+    const data = await res.json();
+    addMessage('Vous: ' + text);
+    addMessage('Bot: ' + data.response, true);
+    document.getElementById('input').value = '';
+}
+
+function addMessage(text, savable=false) {
+    const container = document.getElementById('messages');
+    const div = document.createElement('div');
+    div.className = 'message';
+    div.textContent = text;
+    if (savable) {
+        const btn = document.createElement('button');
+        btn.textContent = 'Sauvegarder';
+        btn.className = 'save-btn';
+        btn.onclick = async () => {
+            await fetch('/api/save', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ text: text.replace(/^Bot: /, '') })
+            });
+            btn.disabled = true;
+            btn.textContent = 'Sauvegardé';
+        };
+        div.appendChild(btn);
+    }
+    container.appendChild(div);
+    container.scrollTop = container.scrollHeight;
+}
+
+document.getElementById('send').addEventListener('click', sendMessage);
+</script>
+</body>
+</html>

--- a/chat_app_js/zerogpt_bridge.py
+++ b/chat_app_js/zerogpt_bridge.py
@@ -1,0 +1,19 @@
+import sys
+import json
+from zerogpt import Client
+
+def main():
+    if len(sys.argv) < 2:
+        print(json.dumps({'error': 'no input'}))
+        return
+    text = sys.argv[1]
+    client = Client()
+    try:
+        resp = client.send_message(text)
+    except Exception as e:
+        print(json.dumps({'error': str(e)}))
+        return
+    print(json.dumps({'response': resp}))
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add a small web chat application in `chat_app_js`
- include a Python bridge to call the `zerogpt` client
- serve a simple HTML frontend
- allow saving messages and ignore node modules

## Testing
- `python3 -m py_compile zerogpt/*.py zerogpt/utils/*.py`
- `node index.js` (manual run)
- `npm install express` (manual run)


------
https://chatgpt.com/codex/tasks/task_e_68686917b8ec832b92449bc24fcc3ba8