### PR TITLE
Add web interface for ZeroGPT

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,18 @@ dummy.load("context.bin")
 
 </details>
 
+### 🌐 Web Interface
+
+An example Flask application is provided to access text generation, image
+creation and image-to-prompt features from a browser.
+
+```bash
+pip install -r requirements.txt
+python web/app.py
+```
+
+Then open <http://localhost:5000> in your browser.
+
 ---
 
 ## ⚙️ Parameters

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pandas
 requests_toolbelt
 packaging
 urlextract
+Flask

--- a/web/app.py
+++ b/web/app.py
@@ -1,0 +1,71 @@
+from flask import Flask, render_template, request
+from werkzeug.utils import secure_filename
+from zerogpt import Client
+from zerogpt.utils.tools import image_to_prompt
+import os
+
+app = Flask(__name__)
+client = Client()
+
+UPLOAD_FOLDER = os.path.join(os.path.dirname(__file__), 'uploads')
+os.makedirs(UPLOAD_FOLDER, exist_ok=True)
+app.config['UPLOAD_FOLDER'] = UPLOAD_FOLDER
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    text_result = None
+    image_result = None
+    prompt_result = None
+
+    if request.method == 'POST':
+        action = request.form.get('action')
+        if action == 'text':
+            prompt = request.form.get('text_prompt', '')
+            instruction = request.form.get('instruction') or None
+            think = bool(request.form.get('think'))
+            uncensored = bool(request.form.get('uncensored'))
+            text_result = client.send_message(
+                prompt,
+                instruction=instruction,
+                think=think,
+                uncensored=uncensored,
+            )
+        elif action == 'image':
+            prompt = request.form.get('image_prompt', '')
+            nsfw = bool(request.form.get('nsfw'))
+            samples = int(request.form.get('samples') or 1)
+            width = int(request.form.get('width') or 768)
+            height = int(request.form.get('height') or 512)
+            seed = int(request.form.get('seed') or -1)
+            steps = int(request.form.get('steps') or 50)
+            negative_prompt = request.form.get('negative_prompt', '')
+            result = client.create_image(
+                prompt,
+                nsfw=nsfw,
+                samples=samples,
+                resolution=(width, height),
+                seed=seed,
+                steps=steps,
+                negative_prompt=negative_prompt,
+            )
+            request_id = result.get('data', {}).get('request_id') if isinstance(result, dict) else None
+            if request_id:
+                images = client.get_image(request_id)
+                image_result = images.images if hasattr(images, 'images') else None
+        elif action == 'prompt':
+            file = request.files.get('image_file')
+            style = request.form.get('prompt_style', 'tag')
+            if file and file.filename:
+                filename = secure_filename(file.filename)
+                path = os.path.join(app.config['UPLOAD_FOLDER'], filename)
+                file.save(path)
+                prompt_result = image_to_prompt(path, prompt_style=style)
+    return render_template(
+        'index.html',
+        text_result=text_result,
+        image_result=image_result,
+        prompt_result=prompt_result,
+    )
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>ZeroGPT Web Interface</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        textarea { width: 100%; height: 80px; }
+        img { max-width: 100%; margin-top: 10px; }
+        form { margin-bottom: 40px; }
+    </style>
+</head>
+<body>
+    <h1>ZeroGPT Web Interface</h1>
+
+    <h2>Text Generation</h2>
+    <form method="post">
+        <input type="hidden" name="action" value="text">
+        <label>Prompt:</label><br>
+        <textarea name="text_prompt"></textarea><br>
+        <label>Instruction:</label><br>
+        <input type="text" name="instruction"><br>
+        <label><input type="checkbox" name="think"> Think mode</label><br>
+        <label><input type="checkbox" name="uncensored"> Uncensored</label><br>
+        <button type="submit">Generate</button>
+    </form>
+    {% if text_result %}
+    <h3>Result</h3>
+    <pre>{{ text_result }}</pre>
+    {% endif %}
+
+    <h2>Image Generation</h2>
+    <form method="post">
+        <input type="hidden" name="action" value="image">
+        <label>Prompt:</label><br>
+        <textarea name="image_prompt"></textarea><br>
+        <label><input type="checkbox" name="nsfw"> NSFW</label><br>
+        <label>Samples: <input type="number" name="samples" value="1"></label><br>
+        <label>Width: <input type="number" name="width" value="768"></label><br>
+        <label>Height: <input type="number" name="height" value="512"></label><br>
+        <label>Seed: <input type="number" name="seed" value="-1"></label><br>
+        <label>Steps: <input type="number" name="steps" value="50"></label><br>
+        <label>Negative Prompt:</label><br>
+        <textarea name="negative_prompt"></textarea><br>
+        <button type="submit">Create Image</button>
+    </form>
+    {% if image_result %}
+    <h3>Generated Images</h3>
+    {% for img in image_result %}
+        <img src="{{ img }}" alt="generated image"><br>
+    {% endfor %}
+    {% endif %}
+
+    <h2>Image to Prompt</h2>
+    <form method="post" enctype="multipart/form-data">
+        <input type="hidden" name="action" value="prompt">
+        <label>Select image: <input type="file" name="image_file"></label><br>
+        <label>Style:
+            <select name="prompt_style">
+                <option value="tag">Tag</option>
+                <option value="creative">Creative</option>
+                <option value="long">Long</option>
+                <option value="short">Short</option>
+            </select>
+        </label><br>
+        <button type="submit">Convert</button>
+    </form>
+    {% if prompt_result %}
+    <h3>Prompt Result</h3>
+    <pre>{{ prompt_result }}</pre>
+    {% endif %}
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Flask-based web interface for text and image generation and image-to-prompt conversion
- document how to run the interface
- include Flask in requirements

## Testing
- `python -m py_compile web/app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895555e1340832b8ab0077da67369d3